### PR TITLE
FIX clearing grid on cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ When clicked: A prompt appears, asking for the size of grid to draw.
 If a non-number or restricted number (not an integer between 1-100, 
 inclusive) is entered, an alert followed by re-prompt appears.
 
-Currently if the cancel button is clicked an empty grid appears.
-    Would it be better to leave the old grid in this case?
+When a number between 1-100 is entered, the current grid is removed, 
+and a new clean grid is created of the size specified.

--- a/script.js
+++ b/script.js
@@ -27,20 +27,16 @@ function gridClear () {
     gridContainer.replaceChildren();
 }
 
-// ==============Set Up Reset Function==============
-function resetGrid () {
-    gridClear();
-    createGridByPrompt ();
-}
-
-// ==============Prompt, Check Response, & Route==============
-function createGridByPrompt () {
+// ==============Prompt, Check Response, & Call Clear + Create==============
+function resetGridWithPrompt () {
     let sizeQuestion = 'How many squares per side should the new grid have? (max 100)';
     let sizePromptResponce = prompt(sizeQuestion);
     let numPromptResponce = Number(sizePromptResponce);
+
     if (sizePromptResponce == null) {
         return sizePromptResponce;
     } else if (numPromptResponce >= 1 && numPromptResponce <= 100) {
+        gridClear();
         createGrid(sizePromptResponce);
     } else {
         invalidResponse()
@@ -49,12 +45,12 @@ function createGridByPrompt () {
 
 function invalidResponse ()  {
     alert("Please enter an integer (whole number) from 1 to 100");
-    createGridByPrompt();
+    resetGridWithPrompt();
 }
 
 // ==============Create User Interface==============
 let resetButton = document.createElement('button');
     resetButton.textContent ='Reset Grid';
-    resetButton.addEventListener('click', resetGrid);
+    resetButton.addEventListener('click', resetGridWithPrompt);
 
     gridContainer.parentNode.insertBefore(resetButton, gridContainer);


### PR DESCRIPTION
Previously the current grid was cleared immediately when the reset button was clicked. Now it waits
until an appropriate response is given, and if the response is cancel, the previous grid remains.